### PR TITLE
fix: display message when no records are found under table page component

### DIFF
--- a/src/layouts/table-page.tsx
+++ b/src/layouts/table-page.tsx
@@ -1,8 +1,8 @@
 import { Typography } from '@mui/material'
-import Breadcrumb from 'ui/navigation/breadcrumbs'
-import Loading from 'ui/feedback/loading'
 import Table from 'ui/data-display/table'
 import TitlePage from 'ui/data-display/title/title-page'
+import Loading from 'ui/feedback/loading'
+import Breadcrumb from 'ui/navigation/breadcrumbs'
 import { BreadcrumbType, Column, EntityMessageTypes } from 'utils/types'
 
 interface TablePageProps<T> {
@@ -24,22 +24,27 @@ export default function TablePage<T>({
   detailRoute,
   onNewClick,
 }: TablePageProps<T>) {
+  const renderTable = () => {
+    if (isLoading) {
+      return <Loading />
+    }
+
+    if (rows.length === 0) {
+      return (
+        <Typography align='center' marginBottom='1em'>
+          Nenhum registro encontrado
+        </Typography>
+      )
+    }
+
+    return <Table detailRoute={detailRoute} columns={columns} rows={rows}></Table>
+  }
+
   return (
     <>
       <Breadcrumb breadcrumbs={breadcrumbs}></Breadcrumb>
       <TitlePage title={messages.title} onNew={onNewClick}></TitlePage>
-      {/* // ! fix this isLoading condition */}
-      {!isLoading && rows.length <= 0 && (
-        <Typography align='center' marginBottom='1em'>
-          Nada aqui para ser mostrado
-        </Typography>
-      )}
-
-      {isLoading ? (
-        <Loading />
-      ) : (
-        <Table detailRoute={detailRoute} columns={columns} rows={rows}></Table>
-      )}
+      {renderTable()}
     </>
   )
 }


### PR DESCRIPTION
Partially resolves https://github.com/luigifsl/tretori-front/issues/20

The table page component is now better organized and has a better layout when no records are found.

https://github.com/luigifsl/tretori-backend/pull/26 Fixes backend part